### PR TITLE
During regular boot don't replace busybox

### DIFF
--- a/custombootimg.mk
+++ b/custombootimg.mk
@@ -18,7 +18,6 @@ $(INSTALLED_BOOTIMAGE_TARGET): $(PRODUCT_OUT)/kernel $(recovery_ramdisk) $(INSTA
 	$(hide) cp $(BOOTREC_DEVICE) $(PRODUCT_OUT)/combinedroot/sbin/
 	$(hide) cp $(BOOTREC_LED) $(PRODUCT_OUT)/combinedroot/sbin/
 
-	$(hide) cp -R $(PRODUCT_OUT)/recovery/root/sbin/* $(PRODUCT_OUT)/root/sbin/
 	$(hide) $(MKBOOTFS) $(PRODUCT_OUT)/root > $(PRODUCT_OUT)/ramdisk.cpio
 	$(hide) cp $(PRODUCT_OUT)/ramdisk.cpio $(PRODUCT_OUT)/combinedroot/sbin/
 	$(hide) $(MKBOOTFS) $(PRODUCT_OUT)/recovery/root > $(PRODUCT_OUT)/ramdisk-recovery.cpio


### PR DESCRIPTION
Since the mount applet of busybox is unable to remount /system
as rw, this change will make the mount applet of toolbox the default,
as it should be.

Change-Id: I6ee5e9a25173e1daa7a4c4d9ef155b6afad5b9f8
