### PR TITLE
sepolicy: update

### DIFF
--- a/sepolicy/admsrv.te
+++ b/sepolicy/admsrv.te
@@ -25,7 +25,7 @@ userdebug_or_eng(`
   allow admsrv fuse:dir create_dir_perms;
   allow admsrv fuse:file create_file_perms;
   allow debuggerd gpu_device:chr_file r_file_perms;
-  # Unfortunately we can't authorize admsrv to do the following things
+  # Unfortunately we cannot authorize admsrv to do the following things
   dontaudit admsrv kmem_device:chr_file r_file_perms;
   dontaudit admsrv self:capability sys_rawio;
   permissive admsrv;

--- a/sepolicy/conn_init.te
+++ b/sepolicy/conn_init.te
@@ -10,7 +10,7 @@ allow conn_init self:capability { net_admin net_raw sys_module };
 allow conn_init self:udp_socket create_socket_perms;
 allow conn_init shell_exec:file { read entrypoint };
 allow conn_init sysfs_wake_lock:file w_file_perms;
-allow conn_init wifi_data_file:file r_file_perms;
+allow conn_init tad_data_file:file r_file_perms;
 allow conn_init modem_file:dir rw_dir_perms;
 allow conn_init modem_file:file create_file_perms;
 allow conn_init system_file:file execute_no_trans;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -92,10 +92,7 @@
 /data/camera(/.*)?	u:object_r:camera_data_file:s0
 /data/mediaserver(/.*)? u:object_r:camera_data_file:s0
 /data/cops.log		u:object_r:radio_data_file:s0
-/data/etc/bluetooth_bdaddr	u:object_r:bluetooth_data_file:s0
-/data/etc/filter	u:object_r:tad_data_file:s0
-/data/etc/wlan_macaddr	u:object_r:wifi_data_file:s0
-/data/etc/threshold	u:object_r:tad_data_file:s0
+/data/etc(/.*)?		u:object_r:tad_data_file:s0
 /data/misc/COPS_DATA_0.csd.*	u:object_r:radio_data_file:s0
 /data/misc/cns.nvd	u:object_r:radio_data_file:s0
 /data/misc/mal_.*	u:object_r:radio_data_file:s0

--- a/sepolicy/simd.te
+++ b/sepolicy/simd.te
@@ -5,7 +5,9 @@ init_daemon_domain(simd)
 
 allow simd self:capability { dac_override net_admin setuid sys_admin };
 allow simd self:{ netlink_socket socket } create_socket_perms;
+allow simd simd_socket:sock_file create_file_perms;
+allow simd socket_device:dir rw_dir_perms;
 allow simd sysfs:file write;
 allow simd tee_device:chr_file rw_file_perms;
-file_type_auto_trans(simd, socket_device, simd_socket)
 file_type_auto_trans(simd, system_data_file, radio_data_file)
+type_transition simd socket_device:sock_file simd_socket;

--- a/sepolicy/tad.te
+++ b/sepolicy/tad.te
@@ -4,10 +4,12 @@ type tad_exec, exec_type, file_type;
 init_daemon_domain(tad)
 
 r_dir_file(tad, modem_file)
-allow tad { bluetooth_data_file wifi_data_file }:file rw_file_perms;
 allow tad block_device:dir search;
 allow tad root_block_device:blk_file rw_file_perms;
 allow tad self:capability dac_override;
+allow tad { system_data_file unlabeled }:dir w_dir_perms;
+allow tad tad_data_file:dir create_dir_perms;
+allow tad tad_data_file:file create_file_perms;
 allow tad tad_socket:sock_file w_file_perms;
 allow tad tmpfs:chr_file rw_file_perms;
-file_type_auto_trans(tad, system_data_file, tad_data_file)
+type_transition tad { system_data_file unlabeled }:dir tad_data_file;


### PR DESCRIPTION
Fix some denials:
taimport (tad) creates /data/etc directory "on fs" (Line 87 of init.st-
ericsson.rc)
simd needs to remove /dev/socket/catd_a

Change-Id: I45270195aef7f78e884dcf675f9b54985b636b738
